### PR TITLE
add missing includes for item_handle.h

### DIFF
--- a/src/store/api/item_handle.h
+++ b/src/store/api/item_handle.h
@@ -16,6 +16,10 @@
 #ifndef ZORBA_STORE_ITEM_HANDLE_H
 #define ZORBA_STORE_ITEM_HANDLE_H
 
+#include <string>
+#include <sstream>
+
+
 namespace zorba 
 {
 


### PR DESCRIPTION
`string` and `stringstream` classes are used, but corresponding includes are missing.
Under gcc 4.8+ that causes build error.
