### PR TITLE
Run import script in parallel

### DIFF
--- a/import_tests.sh
+++ b/import_tests.sh
@@ -1,0 +1,15 @@
+"${ZORBA_SRC_DIR}/test/rbkt/Scripts/w3c/import_w3c_testsuite.sh" "${ZORBA_SRC_DIR}" &
+"${ZORBA_SRC_DIR}/test/rbkt/Scripts/w3c/import_w3c_full_text_testsuite.sh" "${ZORBA_SRC_DIR}" &
+"${ZORBA_SRC_DIR}/test/update/Scripts/import_w3c_update_testsuite.sh" "${ZORBA_SRC_DIR}" &
+cmake -D ZORBA="${ZORBA_BUILD_DIR}/bin/zorba" -D BUILDDIR="${ZORBA_BUILD_DIR}" -P "${ZORBA_SRC_DIR}/test/fots/ImportFOTS.cmake"
+
+FAIL=0
+for job in `jobs -p`
+do
+  wait $job || let "FAIL+=1"
+done
+ 
+if [ $FAIL != "0" ]
+then
+  exit 1
+fi

--- a/test/rbkt/Scripts/w3c/import_w3c_full_text_testsuite.sh
+++ b/test/rbkt/Scripts/w3c/import_w3c_full_text_testsuite.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 WORK_DEFAULT=/tmp
-XQTSURL_DEFAULT=http://zorbatest.lambda.nu:8080/~spungi/XQFTTS_090512.zip
+XQTSURL_DEFAULT=http://w3c-tests.s3.amazonaws.com/XQFTTS_090512.zip
 
 die() {
   echo

--- a/test/rbkt/Scripts/w3c/import_w3c_testsuite.sh
+++ b/test/rbkt/Scripts/w3c/import_w3c_testsuite.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 WORK_DEFAULT=/tmp
-XQTSURL_DEFAULT=http://zorbatest.lambda.nu:8080/~spungi/XQTS_090512.zip
+XQTSURL_DEFAULT=http://w3c-tests.s3.amazonaws.com/XQTS_090512.zip
 
 die() {
   echo

--- a/test/update/Scripts/import_w3c_update_testsuite.sh
+++ b/test/update/Scripts/import_w3c_update_testsuite.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 WORK_DEFAULT=/tmp
-XQUTSURL_DEFAULT=http://zorbatest.lambda.nu:8080/~spungi/XQUTS_090512.zip
+XQUTSURL_DEFAULT=http://w3c-tests.s3.amazonaws.com/XQUTS_090512.zip
 
 die() {
   echo

--- a/wercker.yml
+++ b/wercker.yml
@@ -29,13 +29,11 @@ build:
         - script:
             name: Download & Import W3C test suites
             code: |
+                export ZORBA_SRC_DIR
+                export ZORBA_BUILD_DIR
+                bash "${ZORBA_SRC_DIR}/import_tests.sh"
                 cd "${ZORBA_BUILD_DIR}"
-                "${ZORBA_SRC_DIR}/test/rbkt/Scripts/w3c/import_w3c_testsuite.sh" "${ZORBA_SRC_DIR}"
-                "${ZORBA_SRC_DIR}/test/rbkt/Scripts/w3c/import_w3c_full_text_testsuite.sh" "${ZORBA_SRC_DIR}"
-                "${ZORBA_SRC_DIR}/test/update/Scripts/import_w3c_update_testsuite.sh" "${ZORBA_SRC_DIR}"
-                cmake -D ZORBA="${ZORBA_BUILD_DIR}/bin/zorba" -D BUILDDIR="${ZORBA_BUILD_DIR}" -P "${ZORBA_SRC_DIR}/test/fots/ImportFOTS.cmake"
                 make fots-activate-sets
-
         - script:
             name: Run Tests
             code: |


### PR DESCRIPTION
@MatthiasBrantner ready for review. One big minute seems to be won by running the stuff in parallel. The download speed of the test suite is an order of magnitude higher but it only accounts for a couple of seconds.

One way to speed the process up is to have the test suite already unzipped in the docker container however, the import scripts seem a bit tangled together.
